### PR TITLE
Fix: prevent accessing undefined data-file-id attribute

### DIFF
--- a/js/featherlight.js
+++ b/js/featherlight.js
@@ -21,25 +21,27 @@ Backdrop.behaviors.featherlight = {
     $.featherlight.prototype.afterContent = function() {
       var caption = false;
       var img = this.$currentTarget.find('img');
-      var key = 'id-' + img.attr('data-file-id');
-      var captionAttr = settings.featherlight.files[key];
+      if (img[0].hasAttribute('data-file-id')) {
+        var key = 'id-' + img.attr('data-file-id');
+        var captionAttr = settings.featherlight.files[key];
 
-      if (typeof captionAttr !== 'undefined') {
-        // Caption attribute taken from field formatter settings.
-        if (captionAttr) {
-          var caption = img.attr(captionAttr);
+        if (typeof captionAttr !== 'undefined') {
+          // Caption attribute taken from field formatter settings.
+          if (captionAttr) {
+            var caption = img.attr(captionAttr);
+          }
         }
-      }
-      else {
-        // Caption attribute taken from global settings.
-        if (settings.featherlight.caption_attribute) {
-          var caption = img.attr(settings.featherlight.caption_attribute);
+        else {
+          // Caption attribute taken from global settings.
+          if (settings.featherlight.caption_attribute) {
+            var caption = img.attr(settings.featherlight.caption_attribute);
+          }
         }
-      }
 
-      if (caption) {
-        this.$instance.find('.featherlight-caption').remove();
-        $('<div class="featherlight-caption">').text(caption).appendTo(this.$instance.find('.featherlight-content'));
+        if (caption) {
+          this.$instance.find('.featherlight-caption').remove();
+          $('<div class="featherlight-caption">').text(caption).appendTo(this.$instance.find('.featherlight-content'));
+        }
       }
     };
 


### PR DESCRIPTION
When using featherlight by myself (Adding `$('.selector').featherlightGallery()` in my theme, I got the following error: 
```
Uncaught TypeError: Cannot read property 'id-undefined' of undefined
```